### PR TITLE
Add Nix flake

### DIFF
--- a/.github/workflows/flake.yml
+++ b/.github/workflows/flake.yml
@@ -1,0 +1,25 @@
+name: "Build Nix flake for Amethyst"
+
+on:
+  push:
+    paths:
+      - flake.nix
+      - flake.lock
+      - 'src/**'
+      - 'lib/**'
+
+jobs:
+  build-flake:
+    name: Build Nix flake
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Set up Nix
+        uses: cachix/install-nix-action@v20
+      - name: Build flake
+        run: |
+          nix build .#default
+      - name: Test flake
+        run: |
+          nix run .#default -- --help

--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, stdenv, amber-lang, ... }:
+{ pkgs, stdenv, amber-lang, amethyst-bootstrap, ... }:
 
 stdenv.mkDerivation {
   name = "amethyst";
@@ -6,14 +6,20 @@ stdenv.mkDerivation {
   src = ./.;
 
   buildPhase = ''
-    amber build src/main.ab
+    mkdir -p /tmp/.local/share/amethyst/amber
+    ln -s ${amber-lang}/bin/amber /tmp/.local/share/amethyst/amber/amber.${amber-lang.version}.bin
+    HOME=/tmp amethyst build
   '';
 
   installPhase = ''
-    install -Dm755 src/main.sh $out/bin/amethyst
+    install -Dm755 target/amethyst.sh $out/bin/amethyst
   '';
 
-  nativeBuildInputs = with pkgs;
+  nativeBuildInputs =
     [ amber-lang
+      amethyst-bootstrap
     ];
+
+  propagatedBuildInputs = with pkgs;
+    [ curl jq python3 git ];
 }

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,19 @@
+{ pkgs, stdenv, ... }:
+
+stdenv.mkDerivation {
+  name = "amethyst";
+
+  src = ./.;
+
+  buildPhase = ''
+    amber build src/main.ab
+  '';
+
+  installPhase = ''
+    install -Dm755 src/main.sh $out/bin/amethyst
+  '';
+
+  nativeBuildInputs = with pkgs;
+    [ amber-lang
+    ];
+}

--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, stdenv, ... }:
+{ pkgs, stdenv, amber-lang, ... }:
 
 stdenv.mkDerivation {
   name = "amethyst";

--- a/flake.lock
+++ b/flake.lock
@@ -1,8 +1,30 @@
 {
   "nodes": {
+    "amber": {
+      "inputs": {
+        "naersk": "naersk",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay",
+        "utils": "utils"
+      },
+      "locked": {
+        "lastModified": 1764618977,
+        "narHash": "sha256-v1uJe3vVGKXaZcQzdoYzu/bJKMQnS4IYET4QLPW+J8Y=",
+        "owner": "amber-lang",
+        "repo": "amber",
+        "rev": "eb391e296b9998b5d3e3e4e9b1fd0ba3f4409d47",
+        "type": "github"
+      },
+      "original": {
+        "owner": "amber-lang",
+        "ref": "0.5.1-alpha",
+        "repo": "amber",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
-        "systems": "systems"
+        "systems": "systems_2"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -17,7 +39,45 @@
         "type": "indirect"
       }
     },
+    "naersk": {
+      "inputs": {
+        "nixpkgs": [
+          "amber",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1739824009,
+        "narHash": "sha256-fcNrCMUWVLMG3gKC5M9CBqVOAnJtyRvGPxptQFl5mVg=",
+        "owner": "nix-community",
+        "repo": "naersk",
+        "rev": "e5130d37369bfa600144c2424270c96f0ef0e11d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "master",
+        "repo": "naersk",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
+      "locked": {
+        "lastModified": 1741037377,
+        "narHash": "sha256-SvtvVKHaUX4Owb+PasySwZsoc5VUeTf1px34BByiOxw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "02032da4af073d0f6110540c8677f16d4be0117f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
       "locked": {
         "lastModified": 1773129024,
         "narHash": "sha256-xE4K4JNnZoPSD31MRcPJCqkpG4DfuwX+aH3yo+Stfgs=",
@@ -34,8 +94,30 @@
     },
     "root": {
       "inputs": {
+        "amber": "amber",
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs_2"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "amber",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1741141853,
+        "narHash": "sha256-FauVtC+FbOgkKpGVuQTNxSqrvgbmVc7hFkjn/DacwMo=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "02edad1f19d6dec824e0812e4cdc0aa7930ff8ae",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
       }
     },
     "systems": {
@@ -50,6 +132,39 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
         "type": "github"
       }
     }

--- a/flake.lock
+++ b/flake.lock
@@ -22,6 +22,23 @@
         "type": "github"
       }
     },
+    "amethyst-bootstrap": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1765228764,
+        "narHash": "sha256-p9hx8/c3wR9xTsltUMBYRRjw9Uw2PwSoPNIbuFLpLTE=",
+        "owner": "ArjixWasTaken",
+        "repo": "amethyst",
+        "rev": "8405d5520b697ce03bc19c3b613481dde1bb3f09",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ArjixWasTaken",
+        "ref": "v0.0.1",
+        "repo": "amethyst",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems_2"
@@ -95,6 +112,7 @@
     "root": {
       "inputs": {
         "amber": "amber",
+        "amethyst-bootstrap": "amethyst-bootstrap",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs_2"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,59 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "id": "flake-utils",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1773129024,
+        "narHash": "sha256-xE4K4JNnZoPSD31MRcPJCqkpG4DfuwX+aH3yo+Stfgs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c6979df11dbba72bee1d76c73623af79fc502c8b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -3,12 +3,28 @@
   inputs."nixpkgs".url = github:NixOS/nixpkgs;
   inputs."amber".url = github:amber-lang/amber/0.5.1-alpha;
 
+  inputs."amethyst-bootstrap".url = github:ArjixWasTaken/amethyst/v0.0.1;
+  inputs."amethyst-bootstrap".flake = false;
+
   outputs = { self, nixpkgs, amber, flake-utils, ... }:
   flake-utils.lib.eachDefaultSystem
     (system:
     let pkgs = import nixpkgs { inherit system; };
         amber-lang = amber.outputs.packages.${system}.default;
+
+        amethyst-bootstrap = pkgs.stdenv.mkDerivation {
+          pname = "amethyst";
+          version = "0.0.1";
+
+          src = self.inputs.amethyst-bootstrap;
+
+          nativeBuildInputs = [ amber-lang ];
+          propagatedBuildInputs = with pkgs; [ bc ];
+
+          buildPhase = "amber build src/main.ab";
+          installPhase = "install -Dm755 src/main.sh $out/bin/amethyst";
+        };
     in
-    { packages.default = pkgs.callPackage ./default.nix { inherit amber-lang; };
+    { packages.default = pkgs.callPackage ./default.nix { inherit amber-lang amethyst-bootstrap; };
     });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,12 @@
+{ description = "A version manager, and project manager for Amber";
+
+  inputs."nixpkgs".url = github:NixOS/nixpkgs;
+
+  outputs = { self, nixpkgs, flake-utils, ... }:
+  flake-utils.lib.eachDefaultSystem
+    (system:
+    let pkgs = import nixpkgs { inherit system; };
+    in
+    { packages.default = pkgs.callPackage ./default.nix {};
+    });
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,12 +1,14 @@
 { description = "A version manager, and project manager for Amber";
 
   inputs."nixpkgs".url = github:NixOS/nixpkgs;
+  inputs."amber".url = github:amber-lang/amber/0.5.1-alpha;
 
-  outputs = { self, nixpkgs, flake-utils, ... }:
+  outputs = { self, nixpkgs, amber, flake-utils, ... }:
   flake-utils.lib.eachDefaultSystem
     (system:
     let pkgs = import nixpkgs { inherit system; };
+        amber-lang = amber.outputs.packages.${system}.default;
     in
-    { packages.default = pkgs.callPackage ./default.nix {};
+    { packages.default = pkgs.callPackage ./default.nix { inherit amber-lang; };
     });
 }


### PR DESCRIPTION
Related to #3, introduces distribution-agnostic support for Amethyst by turning it into a [Nix Flake], an importable unit declaring Nix packages.

Among other things, this allows users of Nix to try Amethyst with a single command:
```sh
nix run github:ArjixWasTaken/amethyst -- --help
```

[Nix Flake]: https://wiki.nixos.org/wiki/Flakes

