### PR TITLE
Proposal: check for and use system-wide Amber

### DIFF
--- a/lib/amber_manager.ab
+++ b/lib/amber_manager.ab
@@ -32,21 +32,33 @@ pub fun get_local_versions(): [Text] {
     return amber_bins
 }
 
-pub fun is_system_amber_correct(version: Text): Bool {
-    const data_dir = get_amethyst_data_dir()
-    let versionString = $ amber --version $ failed {
-        return false
-    }
-
-    if text_contains(versionString, version) {
-        info("Found system-wide {versionString}")
-        return true
-    } else {
-        return false
+pub fun get_system_amber() {
+    return $ which amber $ failed {
+        return ""
     }
 }
 
+pub fun is_system_amber_correct(version: Text): Bool {
+    const amber = get_system_amber()
+    if amber == "" {
+        return false
+    }
+
+    let versionString = $ {amber} --version $ failed {
+        return false
+    }
+
+    return text_contains(versionString, version)
+}
+
 pub fun is_available_locally(version: Text): Bool {
+    if version == "system" {
+        if get_system_amber() == "" {
+            fatal("Failed to detect system amber")
+        }
+        return true
+    }
+
     const data_dir = get_amethyst_data_dir()
     $ mkdir -p "{data_dir}/amber" $ failed {
         fatal("Failed to create {data_dir}/amber directory.")
@@ -165,16 +177,15 @@ pub fun set_default(version: Text): Null {
 }
 
 pub fun execute_script(version: Text, script: Text, arguments: [Text]): Null {
-    if version == "system" {
-        // TODO: Add support for using system's amber
-    }
-
     if not is_available_locally(version) {
         fatal("Amber version {version} is not available locally.")
     }
 
     const data_dir = get_amethyst_data_dir()
-    const amber = "{data_dir}/amber/amber.{version}.bin"
+    let amber = "{data_dir}/amber/amber.{version}.bin"
+    if version == "system" {
+        amber = get_system_amber()
+    }
 
     trust $ exec "{amber}" run "{script}" "{arguments}" $
 }

--- a/lib/amber_manager.ab
+++ b/lib/amber_manager.ab
@@ -1,7 +1,7 @@
-import { file_exists, file_extract, file_glob } from "std/fs"
+import { file_exists, file_extract, file_glob, symlink_create } from "std/fs"
 import { array_contains } from "std/array"
 import { file_download } from "std/http"
-import { slice } from "std/text"
+import { slice, text_contains } from "std/text"
 
 import { info, fatal } from "./utils.ab"
 import { get_amber_tags } from "./github.ab"
@@ -30,6 +30,20 @@ pub fun get_local_versions(): [Text] {
     }
 
     return amber_bins
+}
+
+pub fun is_system_amber_correct(version: Text): Bool {
+    const data_dir = get_amethyst_data_dir()
+    let versionString = $ amber --version $ failed {
+        return false
+    }
+
+    if text_contains(versionString, version) {
+        info("Found system-wide {versionString}")
+        return true
+    } else {
+        return false
+    }
 }
 
 pub fun is_available_locally(version: Text): Bool {

--- a/lib/project.ab
+++ b/lib/project.ab
@@ -5,7 +5,7 @@ import { array_pop } from "std/array"
 
 import { parent_dir, basename } from "./path.ab"
 import { info, warn, fatal } from "./utils.ab"
-import { is_available_locally, is_available_remotely, download } from "./amber_manager.ab"
+import { is_available_locally, is_available_remotely, is_system_amber_correct, download } from "./amber_manager.ab"
 
 pub fun locate_project(): [Text] {
     let cwd = trust $ pwd $
@@ -253,6 +253,10 @@ pub fun get_project_amber() {
     }
 
     if not is_available_locally(version) {
+        if is_system_amber_correct(version) {
+            return "system"
+        }
+
         warn("Amber {version} is not available locally.")
         info("Checking if it is available for download...")
 

--- a/lib/project.ab
+++ b/lib/project.ab
@@ -248,10 +248,6 @@ pub fun get_project_amber() {
     const project = locate_project()
     const version = get_ini_value("amethyst", "amber-version")
 
-    if version == "system" {
-        // TODO: Add support for using system's amber
-    }
-
     if not is_available_locally(version) {
         if is_system_amber_correct(version) {
             return "system"

--- a/src/commands/build.ab
+++ b/src/commands/build.ab
@@ -3,6 +3,7 @@ import { info, fatal } from "../../lib/utils.ab"
 import { get_project_amber, require_project, get_ini_value } from "../../lib/project.ab"
 import { get_amethyst_data_dir } from "../../lib/environment.ab"
 import { relative } from "../../lib/path.ab"
+import { get_system_amber } from "../../lib/amber_manager.ab"
 
 pub fun cmd_build(arguments: [Text]): Null {
     const project = require_project()
@@ -24,13 +25,12 @@ pub fun cmd_build(arguments: [Text]): Null {
 
     const data_dir = get_amethyst_data_dir()
     const version = get_project_amber()
-    let amber = ""
 
+    let amber = "{data_dir}/amber/amber.{version}.bin"
     if version == "system" {
-        amber = "amber"
-    } else {
-        amber = "{data_dir}/amber/amber.{version}.bin"
+        amber = get_system_amber()
     }
+
     trust $ exec "{amber}" build "{entry}" "{target}/{name}.sh" $
 
     exit(0)

--- a/src/commands/build.ab
+++ b/src/commands/build.ab
@@ -24,8 +24,13 @@ pub fun cmd_build(arguments: [Text]): Null {
 
     const data_dir = get_amethyst_data_dir()
     const version = get_project_amber()
+    let amber = ""
 
-    const amber = "{data_dir}/amber/amber.{version}.bin"
+    if version == "system" {
+        amber = "amber"
+    } else {
+        amber = "{data_dir}/amber/amber.{version}.bin"
+    }
     trust $ exec "{amber}" build "{entry}" "{target}/{name}.sh" $
 
     exit(0)


### PR DESCRIPTION
This PR lets Amethyst run `amber --version` on whichever version of Amber is in `PATH`, and if the version matches, uses it to build even if the manifest specifies an explicit version.

The check is a substring because, due to Nix sandboxing, the Amber built from the upstream Nix flake will report its version in the form `amber 0.5.1-alpha-nix-eb391e2` even if built from a release tag.