### PR TITLE
Proposal: Patches to v0.0.1 as dedicated bootstrap branch

### DIFF
--- a/amethyst.ini
+++ b/amethyst.ini
@@ -1,9 +1,6 @@
 [amethyst]
 amber-version = 0.5.1-alpha
 
-[dependencies]
-xylitol = https://github.com/zlfn/xylitol.git
-
 [project]
 entry = src/main.ab
 name = amethyst

--- a/lib/amber_manager.ab
+++ b/lib/amber_manager.ab
@@ -1,7 +1,7 @@
-import { file_exists, file_extract, file_glob } from "std/fs"
+import { file_exists, file_extract, file_glob, symlink_create } from "std/fs"
 import { array_contains } from "std/array"
 import { file_download } from "std/http"
-import { slice } from "std/text"
+import { slice, text_contains } from "std/text"
 
 import { info, fatal } from "./utils.ab"
 import { get_amber_tags } from "./github.ab"
@@ -30,6 +30,20 @@ pub fun get_local_versions(): [Text] {
     }
 
     return amber_bins
+}
+
+pub fun is_system_amber_correct(version: Text): Bool {
+    const data_dir = get_amethyst_data_dir()
+    let versionString = $ amber --version $ failed {
+        return false
+    }
+
+    if text_contains(versionString, version) {
+        info("Found system-wide {versionString}")
+        return true
+    } else {
+        return false
+    }
 }
 
 pub fun is_available_locally(version: Text): Bool {

--- a/lib/project.ab
+++ b/lib/project.ab
@@ -5,7 +5,7 @@ import { array_pop } from "std/array"
 
 import { parent_dir, basename } from "./path.ab"
 import { info, warn, fatal } from "./utils.ab"
-import { is_available_locally, is_available_remotely, download } from "./amber_manager.ab"
+import { is_available_locally, is_available_remotely, is_system_amber_correct, download } from "./amber_manager.ab"
 
 pub fun locate_project(): [Text] {
     let cwd = trust $ pwd $
@@ -253,6 +253,10 @@ pub fun get_project_amber() {
     }
 
     if not is_available_locally(version) {
+        if is_system_amber_correct(version) {
+            return "system"
+        }
+
         warn("Amber {version} is not available locally.")
         info("Checking if it is available for download...")
 

--- a/src/commands/build.ab
+++ b/src/commands/build.ab
@@ -24,8 +24,13 @@ pub fun cmd_build(arguments: [Text]): Null {
 
     const data_dir = get_amethyst_data_dir()
     const version = get_project_amber()
+    let amber = ""
 
-    const amber = "{data_dir}/amber/amber.{version}.bin"
+    if version == "system" {
+        amber = "amber"
+    } else {
+        amber = "{data_dir}/amber/amber.{version}.bin"
+    }
     trust $ exec "{amber}" build "{entry}" "{target}/{name}.sh" $
 
     exit(0)


### PR DESCRIPTION
In an effort to clean up and improve Nix support, this PR backports #8 and removes external dependencies from v0.0.1 as a bootstrap version.

This can either be merged, or pushed as a dedicated 'bootstrap' branch which the Nix flake will reference.

In order to keep things simple, I am **not** introducing Nix files into this branch. The entire bootstrap process should be visible from `main`.