### PR TITLE
Bootstrap process for building Amethyst in Nix

### DIFF
--- a/.github/workflows/flake.yml
+++ b/.github/workflows/flake.yml
@@ -20,6 +20,6 @@ jobs:
       - name: Build flake
         run: |
           nix build .#default
-      - name: Test flake
+      - name: Check that flake can build itself
         run: |
-          nix run .#default -- --help
+          nix flake check

--- a/default.nix
+++ b/default.nix
@@ -1,25 +1,14 @@
 { pkgs, stdenv, amber-lang, amethyst-bootstrap, ... }:
 
-stdenv.mkDerivation {
-  name = "amethyst";
+pkgs.callPackage ./nix/buildAmethystApplication.nix {
+  pname = "amethyst";
+  amethyst = amethyst-bootstrap;
 
   src = ./.;
-
-  buildPhase = ''
-    mkdir -p /tmp/.local/share/amethyst/amber
-    ln -s ${amber-lang}/bin/amber /tmp/.local/share/amethyst/amber/amber.${amber-lang.version}.bin
-    HOME=/tmp amethyst build
-  '';
-
-  installPhase = ''
-    install -Dm755 target/amethyst.sh $out/bin/amethyst
-  '';
-
-  nativeBuildInputs =
-    [ amber-lang
-      amethyst-bootstrap
-    ];
+  vendorHash = "sha256-rTXHj8ub/bEa7H83pdGuR9o7CaHn/0Jcyx4O+MArewU=";
 
   propagatedBuildInputs = with pkgs;
-    [ curl jq python3 git ];
+    [ curl jq python3 git bc ];
+
+  passthru.buildAmethystApplication = pkgs.callPackage ./nix/buildAmethystApplication.nix;
 }

--- a/flake.lock
+++ b/flake.lock
@@ -25,16 +25,16 @@
     "amethyst-bootstrap": {
       "flake": false,
       "locked": {
-        "lastModified": 1765228764,
-        "narHash": "sha256-p9hx8/c3wR9xTsltUMBYRRjw9Uw2PwSoPNIbuFLpLTE=",
-        "owner": "ArjixWasTaken",
+        "lastModified": 1774155322,
+        "narHash": "sha256-Ky5+S9Z4QM12g6mjoEK5jwssWa74DMb2E9eXf5pX1A0=",
+        "owner": "thesola10",
         "repo": "amethyst",
-        "rev": "8405d5520b697ce03bc19c3b613481dde1bb3f09",
+        "rev": "05f1aaa3006978ce1f6210864b163e0af4062c55",
         "type": "github"
       },
       "original": {
-        "owner": "ArjixWasTaken",
-        "ref": "v0.0.1",
+        "owner": "thesola10",
+        "ref": "bootstrap",
         "repo": "amethyst",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -34,7 +34,7 @@
     in
     { packages.default = pkgs.amethyst;
 
-      packages.selfBootstrap = pkgs.amethyst.buildAmethystApplication {
+      checks.selfBootstrap = pkgs.amethyst.buildAmethystApplication {
         src = ./.;
         pname = "amethyst";
         vendorHash = "sha256-/A6lintzCKLvNOs55Up091Tu5xJJWTVN/B5wSwgmOyc=";

--- a/flake.nix
+++ b/flake.nix
@@ -1,30 +1,43 @@
 { description = "A version manager, and project manager for Amber";
 
-  inputs."nixpkgs".url = github:NixOS/nixpkgs;
-  inputs."amber".url = github:amber-lang/amber/0.5.1-alpha;
+  inputs."nixpkgs".url = "github:NixOS/nixpkgs";
+  inputs."amber".url = "github:amber-lang/amber/0.5.1-alpha";
 
-  inputs."amethyst-bootstrap".url = github:ArjixWasTaken/amethyst/v0.0.1;
+  # TODO: Switch to upstream bootstrap branch once it exists
+  inputs."amethyst-bootstrap".url = "github:thesola10/amethyst/bootstrap";
   inputs."amethyst-bootstrap".flake = false;
 
   outputs = { self, nixpkgs, amber, flake-utils, ... }:
   flake-utils.lib.eachDefaultSystem
     (system:
-    let pkgs = import nixpkgs { inherit system; };
-        amber-lang = amber.outputs.packages.${system}.default;
+    let pkgs = import nixpkgs
+        { inherit system;
+          overlays = [ (s: super: {
+            amber-lang = amber.outputs.packages.${system}.default;
 
-        amethyst-bootstrap = pkgs.stdenv.mkDerivation {
-          pname = "amethyst";
-          version = "0.0.1";
+            amethyst-bootstrap = s.stdenv.mkDerivation {
+              pname = "amethyst";
+              version = "0.0.1";
 
-          src = self.inputs.amethyst-bootstrap;
+              src = self.inputs.amethyst-bootstrap;
 
-          nativeBuildInputs = [ amber-lang ];
-          propagatedBuildInputs = with pkgs; [ bc ];
+              nativeBuildInputs = [ s.amber-lang ];
+              propagatedBuildInputs = [ s.bc s.curl s.jq s.python3 s.git ];
 
-          buildPhase = "amber build src/main.ab";
-          installPhase = "install -Dm755 src/main.sh $out/bin/amethyst";
+              buildPhase = "amber build src/main.ab";
+              installPhase = "install -Dm755 src/main.sh $out/bin/amethyst";
+            };
+
+            amethyst = s.callPackage ./default.nix {};
+          }) ];
         };
     in
-    { packages.default = pkgs.callPackage ./default.nix { inherit amber-lang amethyst-bootstrap; };
+    { packages.default = pkgs.amethyst;
+
+      packages.selfBootstrap = pkgs.amethyst.buildAmethystApplication {
+        src = ./.;
+        pname = "amethyst";
+        vendorHash = "sha256-/A6lintzCKLvNOs55Up091Tu5xJJWTVN/B5wSwgmOyc=";
+      };
     });
 }

--- a/lib/amber_manager.ab
+++ b/lib/amber_manager.ab
@@ -1,7 +1,7 @@
-import { file_exists, file_extract, file_glob } from "std/fs"
+import { file_exists, file_extract, file_glob, symlink_create } from "std/fs"
 import { array_contains } from "std/array"
 import { file_download } from "std/http"
-import { slice } from "std/text"
+import { slice, text_contains } from "std/text"
 
 import { info, fatal } from "./utils.ab"
 import { get_amber_tags } from "./github.ab"
@@ -30,6 +30,20 @@ pub fun get_local_versions(): [Text] {
     }
 
     return amber_bins
+}
+
+pub fun is_system_amber_correct(version: Text): Bool {
+    const data_dir = get_amethyst_data_dir()
+    let versionString = $ amber --version $ failed {
+        return false
+    }
+
+    if text_contains(versionString, version) {
+        info("Found system-wide {versionString}")
+        return true
+    } else {
+        return false
+    }
 }
 
 pub fun is_available_locally(version: Text): Bool {

--- a/lib/project.ab
+++ b/lib/project.ab
@@ -5,7 +5,7 @@ import { array_pop } from "std/array"
 
 import { parent_dir, basename } from "./path.ab"
 import { info, warn, fatal } from "./utils.ab"
-import { is_available_locally, is_available_remotely, download } from "./amber_manager.ab"
+import { is_available_locally, is_available_remotely, is_system_amber_correct, download } from "./amber_manager.ab"
 
 pub fun locate_project(): [Text] {
     let cwd = trust $ pwd $
@@ -253,6 +253,10 @@ pub fun get_project_amber() {
     }
 
     if not is_available_locally(version) {
+        if is_system_amber_correct(version) {
+            return "system"
+        }
+
         warn("Amber {version} is not available locally.")
         info("Checking if it is available for download...")
 

--- a/nix/buildAmethystApplication.nix
+++ b/nix/buildAmethystApplication.nix
@@ -22,6 +22,8 @@
   # Don't know what to put in here? Leave it empty and Nix will give you the
   # correct hash.
 , vendorHash
+
+, passthru ? {}
 , ... }@as:
 
 let
@@ -51,5 +53,5 @@ stdenv.mkDerivation {
     install -Dm755 target/$project_name.sh $out/bin/$project_name
   '';
 
-  passthru = { inherit vendor; };
+  passthru = { inherit vendor; } // passthru;
 }

--- a/nix/buildAmethystApplication.nix
+++ b/nix/buildAmethystApplication.nix
@@ -1,0 +1,55 @@
+{ pkgs, stdenv, lib, amethyst, amber-lang
+
+  # Name of the project
+, pname ? ""
+
+  # Version of the project
+, version ? ""
+
+  # Name of the resulting package
+, name ? if (version == "") then pname else "${pname}-${version}"
+
+  # Path to the project source code.
+, src
+
+  # Commands that are needed to build the app
+, nativeBuildInputs ? []
+
+  # Commands that will be needed to run the app
+, propagatedBuildInputs ? []
+
+  # Result hash for vendored Amethyst dependencies.
+  # Don't know what to put in here? Leave it empty and Nix will give you the
+  # correct hash.
+, vendorHash
+, ... }@as:
+
+let
+  vendor = import ./vendor.nix { inherit pkgs stdenv amethyst amber-lang name src vendorHash; };
+in
+stdenv.mkDerivation {
+  inherit pname name version src propagatedBuildInputs;
+
+  nativeBuildInputs = [
+    amethyst
+    amber-lang
+  ] ++ nativeBuildInputs;
+
+  configurePhase = ''
+    ln -s ${vendor}/vendor vendor
+    ln -s ${vendor}/amethyst_modules amethyst_modules
+
+    # oh my god this is so ugly don't look
+    export project_name=$(git config -f amethyst.ini --get project.name)
+  '';
+
+  buildPhase = ''
+    HOME=/tmp amethyst build
+  '';
+
+  installPhase = ''
+    install -Dm755 target/$project_name.sh $out/bin/$project_name
+  '';
+
+  passthru = { inherit vendor; };
+}

--- a/nix/vendor.nix
+++ b/nix/vendor.nix
@@ -1,0 +1,35 @@
+{ pkgs, stdenv, amethyst, amber-lang
+, src
+, name
+, vendorHash
+}:
+
+stdenv.mkDerivation {
+  inherit src;
+
+  name = "${name}-vendor";
+  outputHash = vendorHash;
+  outputHashAlgo = "sha256";
+  outputHashMode = "nar";
+
+  dontPatchShebangs = true;
+
+  phases = [ "unpackPhase" "buildPhase" "installPhase" ];
+
+  nativeBuildInputs = [
+    amethyst
+    amber-lang
+    pkgs.cacert
+  ];
+
+  buildPhase = ''
+    amethyst install
+    rm -rf amethyst_modules/*.git/hooks/
+    rm -rf amethyst_modules/*.git/worktrees/*
+  '';
+
+  installPhase = ''
+    mkdir -p $out
+    cp -r amethyst_modules vendor $out/
+  '';
+}

--- a/src/commands/build.ab
+++ b/src/commands/build.ab
@@ -24,8 +24,13 @@ pub fun cmd_build(arguments: [Text]): Null {
 
     const data_dir = get_amethyst_data_dir()
     const version = get_project_amber()
+    let amber = ""
 
-    const amber = "{data_dir}/amber/amber.{version}.bin"
+    if version == "system" {
+        amber = "amber"
+    } else {
+        amber = "{data_dir}/amber/amber.{version}.bin"
+    }
     trust $ exec "{amber}" build "{entry}" "{target}/{name}.sh" $
 
     exit(0)


### PR DESCRIPTION
Sister PR to #10, with a cleaner build process for Amethyst in Nix, as well as infrastructure to allow other Amethyst projects to be packaged in Nix.

Ideally, would require #7 be solved both on `main` and the bootstrap branch, to lift restrictions on developing Amethyst using Amethyst within Nix.

Includes and supersedes #8, whoops.